### PR TITLE
Fix potential double encoding issue on AbsoluteUri

### DIFF
--- a/softaware.Authentication.Basic.AspNetCore.Test/MiddlewareTest.cs
+++ b/softaware.Authentication.Basic.AspNetCore.Test/MiddlewareTest.cs
@@ -10,14 +10,20 @@ namespace softaware.Authentication.Basic.AspNetCore.Test
 {
     public class MiddlewareTest
     {
-        [Fact]
-        public Task Request_MemoryProvider_Authorized()
+        [Theory]
+        [InlineData("api/test")]
+        [InlineData("api/test?query=test")]
+        [InlineData("api/test?query=test test")]
+        [InlineData("api/test?query=test+test")]
+        [InlineData("api/test?query=test%20test")]
+        public Task Request_MemoryProvider_Authorized(string requestUri)
         {
             return this.TestRequestAsync(
                 new MemoryBasicAuthenticationProvider(new Dictionary<string, string>() { { "username", "password" } }),
                 "username",
                 "password",
-                HttpStatusCode.OK);
+                HttpStatusCode.OK,
+                requestUri);
         }
 
         [Theory]
@@ -60,14 +66,15 @@ namespace softaware.Authentication.Basic.AspNetCore.Test
             IBasicAuthorizationProvider basicAuthorizationProvider,
             string username,
             string password,
-            HttpStatusCode expectedStatusCode)
+            HttpStatusCode expectedStatusCode,
+            string requestUri = "api/test")
         {
             using (var client = this.GetHttpClient(
                 new SecureMemoryBasicAuthenticationProvider(new Dictionary<string, string>() { { "username", "password" } }),
                 username,
                 password))
             {
-                var response = await client.GetAsync("api/test");
+                var response = await client.GetAsync(requestUri);
                 Assert.True(response.StatusCode == expectedStatusCode);
             }
         }

--- a/softaware.Authentication.Hmac.AspNetCore.Test/MiddlewareTest.cs
+++ b/softaware.Authentication.Hmac.AspNetCore.Test/MiddlewareTest.cs
@@ -10,14 +10,20 @@ namespace softaware.Authentication.Hmac.AspNetCore.Test
 {
     public class MiddlewareTest
     {
-        [Fact]
-        public Task Request_Authorized()
+        [Theory]
+        [InlineData("api/test")]
+        [InlineData("api/test?query=test")]
+        [InlineData("api/test?query=test test")]
+        [InlineData("api/test?query=test+test")]
+        [InlineData("api/test?query=test%20test")]
+        public Task Request_Authorized(string requestUri)
         {
             return this.TestRequestAsync(
                 new Dictionary<string, string>() { { "appId", "MNpx/353+rW+pqv8UbRTAtO1yoabl8/RFDAv/615u5w=" } },
                 "appId",
                 "MNpx/353+rW+pqv8UbRTAtO1yoabl8/RFDAv/615u5w=",
-                HttpStatusCode.OK);
+                HttpStatusCode.OK,
+                requestUri);
         }
 
         [Theory]
@@ -48,14 +54,15 @@ namespace softaware.Authentication.Hmac.AspNetCore.Test
             IDictionary<string, string> authenticatedApps,
             string appId,
             string apiKey,
-            HttpStatusCode expectedStatusCode)
+            HttpStatusCode expectedStatusCode,
+            string requestUri = "api/test")
         {
             using (var client = this.GetHttpClient(
                 authenticatedApps,
                 appId,
                 apiKey))
             {
-                var response = await client.GetAsync("api/test");
+                var response = await client.GetAsync(requestUri);
                 Assert.True(response.StatusCode == expectedStatusCode);
             }
         }

--- a/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
+++ b/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
@@ -92,7 +92,7 @@ namespace softaware.Authentication.Hmac.AspNetCore
                         req.PathBase.ToUriComponent(),
                         req.Path.ToUriComponent(),
                         req.QueryString.ToUriComponent());
-            var requestUri = WebUtility.UrlEncode(absoluteUri.ToLower());
+            var requestUri = Uri.EscapeDataString(Uri.UnescapeDataString(absoluteUri.ToLower()));
             var requestHttpMethod = req.Method;
 
             if (!this.Options.HmacAuthenticatedApps.TryGetValue(appId, out var apiKey))

--- a/softaware.Authentication.Hmac.Client/ApiKeyDelegatingHandler.cs
+++ b/softaware.Authentication.Hmac.Client/ApiKeyDelegatingHandler.cs
@@ -40,7 +40,7 @@ namespace softaware.Authentication.Hmac.Client
         {
             var requestContentBase64String = string.Empty;
 
-            var requestUri = WebUtility.UrlEncode(request.RequestUri.AbsoluteUri.ToLower());
+            var requestUri = Uri.EscapeDataString(Uri.UnescapeDataString(request.RequestUri.AbsoluteUri.ToLower()));
 
             var requestHttpMethod = request.Method.Method;
 


### PR DESCRIPTION
Hi, thanks for this library. I encountered an issue where the URL had a querystring parameter with a space in it. This, in my project only (I could not replicate it in the tests), was double encoding the space.

The culprit was this line of code `request.RequestUri.AbsoluteUri`, where `AbsoluteUri` was already encoding the space, and then `WebUtility.UrlEncode` was double encoding it. Possibly how the request was sent to the server.

This PR has fixed my specific issue using `Uri.UnescapeDataString` to get the pure URL first, before escaping it with `Uri.EscapeDataString`.

I updated the unit tests, but as I said the issue only occurred in my project, but good to have those test cases in there.

Cheers.