### PR TITLE
Fix request scheme behind proxy

### DIFF
--- a/softaware.Authentication.Hmac.AspNetCore/AuthenticationSchemeOptions.cs
+++ b/softaware.Authentication.Hmac.AspNetCore/AuthenticationSchemeOptions.cs
@@ -11,6 +11,9 @@ namespace softaware.Authentication.Hmac.AspNetCore
 
         public string AuthenticationScheme { get; set; }
 
+        /// <summary>
+        /// If <see langword="true"/>, the request scheme from the 'X-Forwarded-Proto' header is used to validate the request.
+        /// </summary>
         public bool TrustProxy { get; set; }
 
         private IDictionary<string, string> hmacAuthenticatedApps = new Dictionary<string, string>();

--- a/softaware.Authentication.Hmac.AspNetCore/AuthenticationSchemeOptions.cs
+++ b/softaware.Authentication.Hmac.AspNetCore/AuthenticationSchemeOptions.cs
@@ -11,6 +11,8 @@ namespace softaware.Authentication.Hmac.AspNetCore
 
         public string AuthenticationScheme { get; set; }
 
+        public bool TrustProxy { get; set; }
+
         private IDictionary<string, string> hmacAuthenticatedApps = new Dictionary<string, string>();
 
         [Obsolete("Please use the MemoryHmacAuthenticationProvider for configuring the HMAC apps in-memory. This property will be removed in future versions of this package.", error: false)]

--- a/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
+++ b/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
@@ -106,7 +106,7 @@ namespace softaware.Authentication.Hmac.AspNetCore
         {
             var requestContentBase64String = string.Empty;
             var absoluteUri = string.Concat(
-                        req.Scheme,
+                        GetRequestScheme(req),
                         "://",
                         req.Host.ToUriComponent(),
                         req.PathBase.ToUriComponent(),
@@ -176,6 +176,13 @@ namespace softaware.Authentication.Hmac.AspNetCore
 
             this.memoryCache.Set(nonce, requestTimeStamp, DateTimeOffset.UtcNow.AddSeconds(this.Options.MaxRequestAgeInSeconds));
             return false;
+        }
+
+        private string GetRequestScheme(HttpRequest req)
+        {
+            if (this.Options.TrustProxy && req.Headers.TryGetValue("X-Forwarded-Proto", out var scheme))
+                return scheme;
+            return req.Scheme;
         }
 
         private static byte[] ComputeHash(byte[] body)

--- a/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
+++ b/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
@@ -106,7 +106,7 @@ namespace softaware.Authentication.Hmac.AspNetCore
         {
             var requestContentBase64String = string.Empty;
             var absoluteUri = string.Concat(
-                        GetRequestScheme(req),
+                        this.GetRequestScheme(req),
                         "://",
                         req.Host.ToUriComponent(),
                         req.PathBase.ToUriComponent(),
@@ -181,7 +181,9 @@ namespace softaware.Authentication.Hmac.AspNetCore
         private string GetRequestScheme(HttpRequest req)
         {
             if (this.Options.TrustProxy && req.Headers.TryGetValue("X-Forwarded-Proto", out var scheme))
+            {
                 return scheme;
+            }
             return req.Scheme;
         }
 


### PR DESCRIPTION
Hi, thanks for this library.
I encountered an issue when using app behind reverse proxy that terminates SSL connection.
HmacAuthenticationHandler uses request Scheme as part of validation process.
So on Client side https://(...) URL is used but on server side it's http:// (becouse SSL is terminated by proxy).
For this kind of situations X-Forwarded-Proto header (that is added automatically by Proxy - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) can be used.
I updated the unit tests.