### PR TITLE
Use SHA256 for request body hashing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
 
 variables:
   buildConfiguration: 'Release'

--- a/softaware.Authentication.Hmac.AspNetCore/AuthenticationSchemeOptions.cs
+++ b/softaware.Authentication.Hmac.AspNetCore/AuthenticationSchemeOptions.cs
@@ -16,6 +16,17 @@ namespace softaware.Authentication.Hmac.AspNetCore
         /// </summary>
         public bool TrustProxy { get; set; }
 
+        /// <summary>
+        /// If <see langword="true"/>, the request body hash will be validated with MD5 hash and SHA265 hash.
+        /// Note that this setting is only relevant when the http request has a body.
+        /// (Default: <see langword="true"/>)
+        /// </summary>
+        /// <remarks>
+        /// This setting helps upgrading from MD5 to SHA256 hash without breaking changes.
+        /// </remarks>
+        [Obsolete("Will be removed in the next major version as only SHA256 request body hashing will be supported in future.")]
+        public bool AllowMD5AndSHA256RequestBodyHash { get; set; } = true;
+
         private IDictionary<string, string> hmacAuthenticatedApps = new Dictionary<string, string>();
 
         [Obsolete("Please use the MemoryHmacAuthenticationProvider for configuring the HMAC apps in-memory. This property will be removed in future versions of this package.", error: false)]

--- a/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
+++ b/softaware.Authentication.Hmac.AspNetCore/HmacAuthenticationHandler.cs
@@ -189,12 +189,12 @@ namespace softaware.Authentication.Hmac.AspNetCore
 
         private static byte[] ComputeHash(byte[] body)
         {
-            using (var md5 = MD5.Create())
+            using (var sha256 = SHA256.Create())
             {
                 byte[] hash = null;
                 if (body.Length != 0)
                 {
-                    hash = md5.ComputeHash(body);
+                    hash = sha256.ComputeHash(body);
                 }
 
                 return hash;

--- a/softaware.Authentication.Hmac.AspNetCore/softaware.Authentication.Hmac.AspNetCore.csproj
+++ b/softaware.Authentication.Hmac.AspNetCore/softaware.Authentication.Hmac.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <Authors>softaware gmbh</Authors>
     <Company>softaware gmbh</Company>
     <Description>A library which adds support for HMAC authentication in ASP.NET Core projects.</Description>
-    <Version>3.3.0</Version>
+    <Version>4.0.0</Version>
     <RepositoryUrl>https://github.com/softawaregmbh/library-authentication</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>softaware, authentication, HMAC, AspNetCore</PackageTags>

--- a/softaware.Authentication.Hmac.AspNetCore/softaware.Authentication.Hmac.AspNetCore.csproj
+++ b/softaware.Authentication.Hmac.AspNetCore/softaware.Authentication.Hmac.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <Authors>softaware gmbh</Authors>
     <Company>softaware gmbh</Company>
     <Description>A library which adds support for HMAC authentication in ASP.NET Core projects.</Description>
-    <Version>4.0.0</Version>
+    <Version>3.4.0</Version>
     <RepositoryUrl>https://github.com/softawaregmbh/library-authentication</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>softaware, authentication, HMAC, AspNetCore</PackageTags>

--- a/softaware.Authentication.Hmac.Client/ApiKeyDelegatingHandler.cs
+++ b/softaware.Authentication.Hmac.Client/ApiKeyDelegatingHandler.cs
@@ -56,11 +56,12 @@ namespace softaware.Authentication.Hmac.Client
             if (request.Content != null)
             {
                 var content = await request.Content.ReadAsByteArrayAsync();
-                var md5 = MD5.Create();
-
-                // Hashing the request body, any change in request body will result in different hash, we'll incure message integrity
-                var requestContentHash = md5.ComputeHash(content);
-                requestContentBase64String = Convert.ToBase64String(requestContentHash);
+                using (var sha256 = SHA256.Create())
+                {
+                    // Hashing the request body, any change in request body will result in different hash, we'll incure message integrity
+                    var requestContentHash = sha256.ComputeHash(content);
+                    requestContentBase64String = Convert.ToBase64String(requestContentHash);
+                }
             }
 
             // Creating the raw signature string

--- a/softaware.Authentication.Hmac.Client/ApiKeyDelegatingHandler.cs
+++ b/softaware.Authentication.Hmac.Client/ApiKeyDelegatingHandler.cs
@@ -13,11 +13,18 @@ namespace softaware.Authentication.Hmac.Client
     {
         private readonly string appId;
         private readonly string apiKey;
+        private readonly RequestBodyHashingMethod requestBodyHashingMethod;
 
         public ApiKeyDelegatingHandler(string appId, string apiKey)
+            : this(appId, apiKey, RequestBodyHashingMethod.MD5)
+        {
+        }
+
+        public ApiKeyDelegatingHandler(string appId, string apiKey, RequestBodyHashingMethod requestBodyHashingMethod)
         {
             this.appId = !string.IsNullOrWhiteSpace(appId) ? appId : throw new ArgumentNullException(nameof(appId));
             this.apiKey = !string.IsNullOrWhiteSpace(apiKey) ? apiKey : throw new ArgumentNullException(nameof(apiKey));
+            this.requestBodyHashingMethod = requestBodyHashingMethod;
 
             try
             {
@@ -30,10 +37,18 @@ namespace softaware.Authentication.Hmac.Client
         }
 
         public ApiKeyDelegatingHandler(string appId, string apiKey, HttpMessageHandler innerHandler)
+            : this(appId, apiKey, RequestBodyHashingMethod.MD5, innerHandler)
+        {
+            this.appId = appId ?? throw new ArgumentNullException(nameof(appId));
+            this.apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
+        }
+
+        public ApiKeyDelegatingHandler(string appId, string apiKey, RequestBodyHashingMethod requestBodyHashingMethod, HttpMessageHandler innerHandler)
             : base(innerHandler)
         {
             this.appId = appId ?? throw new ArgumentNullException(nameof(appId));
             this.apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
+            this.requestBodyHashingMethod = requestBodyHashingMethod;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -56,10 +71,10 @@ namespace softaware.Authentication.Hmac.Client
             if (request.Content != null)
             {
                 var content = await request.Content.ReadAsByteArrayAsync();
-                using (var sha256 = SHA256.Create())
+                using (var hashAlgorithm = this.GetHashAlgorithm())
                 {
                     // Hashing the request body, any change in request body will result in different hash, we'll incure message integrity
-                    var requestContentHash = sha256.ComputeHash(content);
+                    var requestContentHash = hashAlgorithm.ComputeHash(content);
                     requestContentBase64String = Convert.ToBase64String(requestContentHash);
                 }
             }
@@ -84,6 +99,19 @@ namespace softaware.Authentication.Hmac.Client
             var response = await base.SendAsync(request, cancellationToken);
 
             return response;
+        }
+
+        private HashAlgorithm GetHashAlgorithm()
+        {
+            switch (this.requestBodyHashingMethod)
+            {
+                case RequestBodyHashingMethod.MD5:
+                    return MD5.Create();
+                case RequestBodyHashingMethod.SHA256:
+                    return SHA256.Create();
+                default:
+                    throw new NotSupportedException($"requestBodyHashingMethod {requestBodyHashingMethod} is not supported.");
+            }
         }
     }
 }

--- a/softaware.Authentication.Hmac.Client/RequestBodyHashingMethod.cs
+++ b/softaware.Authentication.Hmac.Client/RequestBodyHashingMethod.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace softaware.Authentication.Hmac.Client
+{
+    /// <summary>
+    /// Defines which hashing method should be used for the http request body.
+    /// </summary>
+    public enum RequestBodyHashingMethod
+    {
+        [Obsolete("Will be removed in the next major version release.")]
+        MD5 = 0,
+        SHA256 = 1
+    }
+}

--- a/softaware.Authentication.Hmac.Client/softaware.Authentication.Hmac.Client.csproj
+++ b/softaware.Authentication.Hmac.Client/softaware.Authentication.Hmac.Client.csproj
@@ -8,7 +8,7 @@
     <Company>softaware gmbh</Company>
     <Authors>softaware gmbh</Authors>
     <Description>A client library for HMAC authentication.</Description>
-    <Version>2.0.0</Version>
+    <Version>1.2.0</Version>
     <RepositoryUrl>https://github.com/softawaregmbh/library-authentication</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>softaware, authentication, HMAC</PackageTags>

--- a/softaware.Authentication.Hmac.Client/softaware.Authentication.Hmac.Client.csproj
+++ b/softaware.Authentication.Hmac.Client/softaware.Authentication.Hmac.Client.csproj
@@ -8,7 +8,7 @@
     <Company>softaware gmbh</Company>
     <Authors>softaware gmbh</Authors>
     <Description>A client library for HMAC authentication.</Description>
-    <Version>1.1.1</Version>
+    <Version>2.0.0</Version>
     <RepositoryUrl>https://github.com/softawaregmbh/library-authentication</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>softaware, authentication, HMAC</PackageTags>


### PR DESCRIPTION
This PR improves the hashing algorithm for the request body hashing and upgrades from MD5 to SHA256.

As we don't want to introduce breaking changes, we do the following:
* Add setting for client to choose hashing algorithm for request body hashing. The default stays at MD5 for now to prevent breaking changes.
* Add setting for server: `AllowMD5AndSHA256RequestBodyHash`. If `true`, it checks the request body hash with SHA-256 and if that fails it checks the body hash again with MD5.

With this approach we can upgrade and deploy the server part first and then deploy the client part with SHA-256 setting afterwards. This ensures that we don't need to deploy server and client at the exact same time and avoid downtime.