### PR TITLE
Fix SAS validation for query parameters which require url encoding

### DIFF
--- a/softaware.Authentication.SasToken.AspNetCore.Test/MiddlewareTest.cs
+++ b/softaware.Authentication.SasToken.AspNetCore.Test/MiddlewareTest.cs
@@ -110,6 +110,27 @@ namespace softaware.Authentication.Basic.AspNetCore.Test
                 HttpStatusCode.OK);
         }
 
+        [Fact]
+        public async Task Request_AdditionalParameterInSignature_WithUrlEncodingOfAdditionalParameters_Authorized()
+        {
+            var relativeUrl = "api/test" +
+                await this.urlGenerator.GenerateSasTokenQueryStringAsync(
+                    "/api/test",
+                    new Dictionary<string, StringValues> { ["parameter"] = new StringValues("1 & 1") },
+                    DateTime.UtcNow,
+                    DateTime.UtcNow.AddMinutes(5),
+                    QueryParameterHandlingType.DenyAdditionalQueryParameters,
+                    appendQueryParameters: true,
+                    CancellationToken.None);
+
+            await this.TestRequestAsync(
+                relativeUrl,
+                HttpStatusCode.OK);
+
+            // Make sure that provided query parameters are URL encoded.
+            Assert.Contains("&parameter=1+%26+1", relativeUrl);
+        }
+
         [Theory]
         [InlineData("1", "1", HttpStatusCode.OK)]
         [InlineData("1", "2", HttpStatusCode.Unauthorized)]

--- a/softaware.Authentication.SasToken.AspNetCore/softaware.Authentication.SasToken.AspNetCore.csproj
+++ b/softaware.Authentication.SasToken.AspNetCore/softaware.Authentication.SasToken.AspNetCore.csproj
@@ -8,7 +8,7 @@
 	<Authors>softaware gmbh</Authors>
 	<Company>softaware gmbh</Company>
 	<Description>A library which adds support for SAS token authentication in ASP.NET Core projects.</Description>
-	<Version>1.1.1</Version>
+	<Version>1.1.2</Version>
 	<RepositoryUrl>https://github.com/softawaregmbh/library-authentication</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PackageTags>softaware, authentication, SAS, AspNetCore</PackageTags>

--- a/softaware.Authentication.SasToken/Generators/SasTokenUrlGenerator.cs
+++ b/softaware.Authentication.SasToken/Generators/SasTokenUrlGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Globalization;
+using System.Web;
 using Microsoft.Extensions.Primitives;
 using softaware.Authentication.SasToken.Models;
 
@@ -22,6 +23,7 @@ namespace softaware.Authentication.SasToken.Generators
                 appendQueryParameters: false,
                 cancellationToken);
 
+        /// <param name="queryParameters">Additional query parameters. There is no need for the caller to URL encode the parameters. This is done here for you.</param>
         /// <param name="endpoint">The endpoint of the URI starting with a leading "/".</param>
         /// <param name="appendQueryParameters"><see langword="true"/>, if the provided query parameters should be appended to the query string.</param>
         public async Task<string> GenerateSasTokenQueryStringAsync(
@@ -52,7 +54,7 @@ namespace softaware.Authentication.SasToken.Generators
 
             if (appendQueryParameters && queryParameters.Any())
             {
-                var queryParametersString = string.Join("&", queryParameters.Select(q => $"{q.Key}={q.Value}"));
+                var queryParametersString = string.Join("&", queryParameters.Select(q => $"{q.Key}={HttpUtility.UrlEncode(q.Value)}"));
                 sasQueryString += $"&{queryParametersString}";
             }
 
@@ -79,6 +81,7 @@ namespace softaware.Authentication.SasToken.Generators
 
         /// <param name="baseUrl">The base url <strong>without</strong> trailing "/".</param>
         /// <param name="endpoint">The endpoint of the URI starting with a leading "/".</param>
+        /// <param name="queryParameters">Additional query parameters. There is no need for the caller to URL encode the parameters. This is done here for you.</param>
         /// <param name="appendQueryParameters"><see langword="true"/>, if the provided query parameters should be appended to the query string.</param>
         public async Task<Uri> GenerateSasTokenUriAsync(
             string baseUrl,

--- a/softaware.Authentication.SasToken/softaware.Authentication.SasToken.csproj
+++ b/softaware.Authentication.SasToken/softaware.Authentication.SasToken.csproj
@@ -12,7 +12,7 @@
 	<RepositoryType>git</RepositoryType>
 	<PackageTags>softaware, authentication, SAS</PackageTags>
 	<PackageProjectUrl>https://github.com/softawaregmbh/library-authentication</PackageProjectUrl>
-	<Version>1.0.3</Version>
+	<Version>1.0.4</Version>
 	<Description>Core library for SAS token authentication</Description>
 	<PackageIcon>package-icon.png</PackageIcon>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
The generated SAS token needs to URL-encode all provided query parameters so that the hashing of the generating SAS token and the hashing of the incoming url use the same, non-url-encoded parameter values for hashing.

Fixes 401 errors when SAS tokens with query parameters which include special chars are generated.