### PR TITLE
Use `CryptographicOperations.FixedTimeEquals` for password and hash comparison to prevent timing-attacks

### DIFF
--- a/softaware.Authentication.Basic.AspNetCore/AuthorizationProvider/MemoryBasicAuthenticationProvider.cs
+++ b/softaware.Authentication.Basic.AspNetCore/AuthorizationProvider/MemoryBasicAuthenticationProvider.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace softaware.Authentication.Basic.AspNetCore.AuthorizationProvider
@@ -16,8 +18,11 @@ namespace softaware.Authentication.Basic.AspNetCore.AuthorizationProvider
         public Task<bool> IsAuthorizedAsync(string username, string password)
         {
             return Task.FromResult(
-                this.credentials.TryGetValue(username, out var secureString) &&
-                password == secureString);
+                this.credentials.TryGetValue(username, out var storedPassword) &&
+                EqualsFixedLength(password, storedPassword));
         }
+
+        private static bool EqualsFixedLength(string storedPassword, string inputPassword)
+            => CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(storedPassword), Encoding.UTF8.GetBytes(inputPassword));
     }
 }

--- a/softaware.Authentication.Basic.AspNetCore/softaware.Authentication.Basic.AspNetCore.csproj
+++ b/softaware.Authentication.Basic.AspNetCore/softaware.Authentication.Basic.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>5.0.1</Version>
+    <Version>5.0.2</Version>
     <PackageProjectUrl>https://github.com/softawaregmbh/library-authentication</PackageProjectUrl>
     <RepositoryUrl>https://github.com/softawaregmbh/library-authentication</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -15,7 +15,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <PackageReleaseNotes>Hotfix if the user uses colon character in password</PackageReleaseNotes>
+    <PackageReleaseNotes>Use CryptographicOperations.FixedTimeEquals for password comparision to prevent timing attacks</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/softaware.Authentication.Hmac.AspNetCore/softaware.Authentication.Hmac.AspNetCore.csproj
+++ b/softaware.Authentication.Hmac.AspNetCore/softaware.Authentication.Hmac.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Authors>softaware gmbh</Authors>
     <Company>softaware gmbh</Company>
     <Description>A library which adds support for HMAC authentication in ASP.NET Core projects.</Description>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <RepositoryUrl>https://github.com/softawaregmbh/library-authentication</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>softaware, authentication, HMAC, AspNetCore</PackageTags>
@@ -16,7 +16,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <PackageReleaseNotes>Update to net8.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Use CryptographicOperations.FixedTimeEquals for hash comparision to prevent timing attacks</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Using [`CryptographicOperations.FixedTimeEquals`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptographicoperations.fixedtimeequals?view=net-9.0) to prevent timing attacks.

See also [here](https://vcsjones.dev/fixed-time-equals-dotnet-core/) for details.

Also updating `Microsoft.Extensions.Caching.Memory` due to vulnerability.